### PR TITLE
added HydRand and  RandRunner to the section on randomness beacons

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,8 +107,12 @@
     <a href='http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.28.4015&rep=rep1&type=pdf'>Efficient Accumulators without Trapdoor Extended Abstract</a></p>
 
     <h2>randomness beacons</h2>
+    <p>2020—<strong>Schindler, Judmayer, Hittmeir, Stifter, Weippl</strong>
+    <a href='https://eprint.iacr.org/2020/942.pdf'>RandRunner: Distributed Randomness from Trapdoor VDFs with Strong Uniqueness</a></p>
     <p>2020—<strong>Baum, David, Dowsley, Nielsen, Oechsner</strong>
     <a href='https://eprint.iacr.org/2020/784.pdf'>CRAFT: Composable Randomness and Almost Fairness from Time</a></p>
+    <p>2020—<strong>Schindler, Judmayer, Stifter, Weippl</strong>
+    <a href='https://eprint.iacr.org/2018/319.pdf'>HydRand: Practical Continuous Distributed Randomnesss</a></p>
     <p>2018—<strong>Drake</strong>
     <a href='https://ethresear.ch/t/minimal-vdf-randomness-beacon/3566'>Minimal VDF Randomness Beacon</a></p>
     <p>2018—<strong>Drake</strong>

--- a/index.html
+++ b/index.html
@@ -111,14 +111,14 @@
     <a href='https://eprint.iacr.org/2020/942.pdf'>RandRunner: Distributed Randomness from Trapdoor VDFs with Strong Uniqueness</a></p>
     <p>2020—<strong>Baum, David, Dowsley, Nielsen, Oechsner</strong>
     <a href='https://eprint.iacr.org/2020/784.pdf'>CRAFT: Composable Randomness and Almost Fairness from Time</a></p>
-    <p>2020—<strong>Schindler, Judmayer, Stifter, Weippl</strong>
-    <a href='https://eprint.iacr.org/2018/319.pdf'>HydRand: Practical Continuous Distributed Randomnesss</a></p>
     <p>2018—<strong>Drake</strong>
     <a href='https://ethresear.ch/t/minimal-vdf-randomness-beacon/3566'>Minimal VDF Randomness Beacon</a></p>
     <p>2018—<strong>Drake</strong>
     <a href='https://ethresear.ch/t/vdf-based-rng-with-linear-lookahead/2573'>VDF-based RNG with Linear Lookahead</a></p>
     <p>2018—<strong>Jensen, Kristensen, Michno</strong>
     <a href='https://projekter.aau.dk/projekter/files/281196661/main.pdf'>Developing a Trustworthy Randomness Beacon for the Public</a></p>
+    <p>2018—<strong>Schindler, Judmayer, Stifter, Weippl</strong>
+    <a href='https://eprint.iacr.org/2018/319.pdf'>HydRand: Practical Continuous Distributed Randomnesss</a></p>
     <p>2017—<strong>Bünz, Goldfeder, Bonneau</strong>
     <a href='http://www.jbonneau.com/doc/BGB17-IEEESB-proof_of_delay_ethereum.pdf'>Proofs-of-delay and Randomness Beacons in Ethereum</a></p>
     <p>2016—<strong>Darknet</strong>


### PR DESCRIPTION
This pull request proposes to add links to the HydRand and RandRunner papers:

- The HydRand paper, published at IEEE S&P 2020, describes a standalone randomness beacon protocol based on publicly-verifiable secret sharing and provides an extensive survey on various approaches for generating distributed randomness

- RandRunner is a very recent, VDF-based protocol by the same authors which provides a unique set of security guarantees while offering excellent scalability, performance and responsiveness.

We would highly appreciate listing our papers on the website and would like to become more involved with the VDF Research community.