### PR TITLE
Add RandChain paper

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,8 @@
     <a href='http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.28.4015&rep=rep1&type=pdf'>Efficient Accumulators without Trapdoor Extended Abstract</a></p>
 
     <h2>randomness beacons</h2>
+    <p>2020—<strong>Han, Yu, Lin</strong>
+    <a href='https://eprint.iacr.org/2020/1033.pdf'>RandChain: Decentralised Randomness Beacon from Sequential Proof-of-Work</a></p>
     <p>2020—<strong>Schindler, Judmayer, Hittmeir, Stifter, Weippl</strong>
     <a href='https://eprint.iacr.org/2020/942.pdf'>RandRunner: Distributed Randomness from Trapdoor VDFs with Strong Uniqueness</a></p>
     <p>2020—<strong>Baum, David, Dowsley, Nielsen, Oechsner</strong>


### PR DESCRIPTION
This PR proposes to add the RandChain paper, which makes two contributions close to vdfresearch's interest.

- This paper formally proposes Sequential Proof-of-Work (SeqPoW), a PoW variant that is sequential, i.e., cannot be solved faster by parallelism. Roughly it can be seen as a VDF with randomised time parameter. The concrete SeqPoW construction is based on VDFs.
- This paper introduces RandChain, a new family of Decentralised Randomness Beacon protocols, and analyses its security and performance. RandChain is constructed from SeqPoW and Nakamoto consensus, and is simple, secure, scalable, and energy-efficient at the same time.